### PR TITLE
MNT: unpin databroker, python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,8 @@ requirements:
     - pip
     - setuptools
   run:
-    - python >=3.8, <3.10
-    - databroker <2.0.0a
+    - python >=3.8
+    - databroker
     - pyyaml
 
 test:


### PR DESCRIPTION
v0.4.6
====================

**Fixed:**

* Make the package compatible with `databroker==2.0.0b9`.